### PR TITLE
fixed float passed to shape bug

### DIFF
--- a/ccalnoir/information.py
+++ b/ccalnoir/information.py
@@ -1856,7 +1856,7 @@ def fastkde(x, y, gridsize=(200, 200), extents=None, nocorrelation=False, weight
     # Next, make a 2D histogram of x & y.
     # Exploit a sparse coo_matrix avoiding np.histogram2d due to excessive
     # memory usage with many points
-    grid = coo_matrix((weights, xyi), shape=(nx, ny)).toarray()
+    grid = coo_matrix((weights, xyi), shape=(int(nx), int(ny))).toarray()
 
     # Kernel Preliminary Calculations ---------------------------------------
     # Calculate the covariance matrix (in pixel coords)


### PR DESCRIPTION
Using `numpy==1.17.2`, I was getting the following error for any IC computation:

```   
  File "/opt/conda/envs/python3.7/lib/python3.7/site-packages/ccalnoir/information.py", line 1859, in fastkde
    grid = coo_matrix((weights, xyi), shape=(nx, ny)).toarray()
  File "/opt/conda/envs/python3.7/lib/python3.7/site-packages/scipy/sparse/coo.py", line 156, in __init__
    self._shape = check_shape((M, N))
  File "/opt/conda/envs/python3.7/lib/python3.7/site-packages/scipy/sparse/sputils.py", line 279, in check_shape
    new_shape = tuple(operator.index(arg) for arg in args)
  File "/opt/conda/envs/python3.7/lib/python3.7/site-packages/scipy/sparse/sputils.py", line 279, in <genexpr>
    new_shape = tuple(operator.index(arg) for arg in args)
TypeError: 'numpy.float64' object cannot be interpreted as an integer
```

According to [this StackOverflow](https://stackoverflow.com/questions/24003431/python-typeerror-numpy-float64-object-cannot-be-interpreted-as-an-integer) this is a problem in later versions of `numpy` that don't always do implicit `float` to `int` conversions correctly. I explicitly converted the `shape` parameters to `int` and it fixed the bug. I haven't tested on any other versions of `numpy` but I assume this will be backwards-compatible.