### PR TITLE
Int conversion of kde grid shape parameters for numpy compatibility (and `read_gmt()`)

### DIFF
--- a/ccalnoir/elemental.py
+++ b/ccalnoir/elemental.py
@@ -237,7 +237,7 @@ def read_gmt(gmt_file_path, drop_description=True):
 
             lines.append(split[:2] + [gene for gene in set(split[2:]) if gene])
 
-    df = DataFrame(lines)
+    df = pd.DataFrame(lines)
 
     df.set_index(0, inplace=True)
 

--- a/ccalnoir/elemental.py
+++ b/ccalnoir/elemental.py
@@ -223,3 +223,36 @@ def get_file_from_server(gene_pattern_url, file_type='GCT'):
         data = file_io.read()
 
     return data
+
+## Additional IO from CCAL (12/25/21)
+def read_gmt(gmt_file_path, drop_description=True):
+
+    lines = []
+
+    with open(gmt_file_path) as gmt_file:
+
+        for line in gmt_file:
+
+            split = line.strip().split(sep="\t")
+
+            lines.append(split[:2] + [gene for gene in set(split[2:]) if gene])
+
+    df = DataFrame(lines)
+
+    df.set_index(0, inplace=True)
+
+    df.index.name = "Gene Set"
+
+    if drop_description:
+
+        df.drop(1, axis=1, inplace=True)
+
+        df.columns = tuple("Gene {}".format(i) for i in range(0, df.shape[1]))
+
+    else:
+
+        df.columns = ("Description",) + tuple(
+            "Gene {}".format(i) for i in range(0, df.shape[1] - 1)
+        )
+
+    return df

--- a/ccalnoir/information.py
+++ b/ccalnoir/information.py
@@ -598,7 +598,7 @@ def make_match_panel(target,
             key=lambda i: scores.loc[i, 'Score'],
             reverse=not scores_ascending)
 
-    scores_to_plot = scores.ix[indices]
+    scores_to_plot = scores.iloc[indices]
     features_to_plot = features.loc[scores_to_plot.index]
 
     # Make annotations
@@ -623,6 +623,7 @@ def make_match_panel(target,
                          features_type, title, target_annotation_kwargs,
                          plot_column_names, max_ytick_size, file_path_plot, dpi)
 
+    if file_path_prefix:
         # 2018-01-17 printing hyperlink to PDF and TXT:
         print("-----------------------------------------------")
         print("The PDF of this heatmap can be downloaded here:\n")
@@ -637,8 +638,7 @@ def make_match_panel(target,
     # move the column to head of list using index, pop and insert
     cols.insert(0, cols.pop(cols.index('Score')))
     print('done!')
-    # use ix to reorder
-    return scores.ix[:, cols]
+    return scores.loc[:, cols]
 
 def drop_df_slices(df,
                    axis,

--- a/ccalnoir/information.py
+++ b/ccalnoir/information.py
@@ -598,7 +598,7 @@ def make_match_panel(target,
             key=lambda i: scores.loc[i, 'Score'],
             reverse=not scores_ascending)
 
-    scores_to_plot = scores.iloc[indices]
+    scores_to_plot = scores.loc[indices]
     features_to_plot = features.loc[scores_to_plot.index]
 
     # Make annotations

--- a/ccalnoir/information.py
+++ b/ccalnoir/information.py
@@ -1836,6 +1836,10 @@ def fastkde(x, y, gridsize=(200, 200), extents=None, nocorrelation=False, weight
 
     nx, ny = gridsize
 
+    ## Check grid dimensions are integers to address numpy data type errors
+    nx = int(nx)
+    ny = int(ny)
+
     # Make the sparse 2d-histogram -------------------------------------------
     # Default extents are the extent of the data
     if extents is None:


### PR DESCRIPTION
This pull request implements explicit casting of the `nx` and `ny` grid shape parameters for compatibility with some of the stricter typing in newer versions of `numpy`. 